### PR TITLE
[Fix] Fix the adminshop bug to buy 64 enderpearl + click several times to confirm purchase

### DIFF
--- a/src/main/java/fr/communaywen/core/adminshop/menu/buy/AdminShopBuy.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/buy/AdminShopBuy.java
@@ -94,9 +94,7 @@ public class AdminShopBuy extends Menu {
         return new ItemBuilder(this, Objects.requireNonNull(Material.getMaterial(material == null ? items.named() : items.named() + "_" + material)), itemMeta -> {
             itemMeta.setDisplayName(items.getName());
             updateItemMeta(itemMeta);
-        }).setOnClick(event -> {
-            new AdminShopBuyConfirm(getOwner(), items, number.get(), material).open();
-        });
+        }).setNextMenu(new AdminShopBuyConfirm(getOwner(), items, number.get(), material));
     }
 
     private void updateItemMeta(ItemMeta itemMeta) {
@@ -117,6 +115,8 @@ public class AdminShopBuy extends Menu {
                 updateItemMeta(itemMeta);
                 itemStack.setItemMeta(itemMeta);
             }
+
+            inventory.setItem(13, createItemDisplay());
         }
         getOwner().updateInventory();
     }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/buy/AdminShopBuyConfirm.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/buy/AdminShopBuyConfirm.java
@@ -71,7 +71,7 @@ public class AdminShopBuyConfirm extends Menu {
                 if(balance < (items.getPrize() * quantity)) {
                     getOwner().sendMessage(ChatColor.RED + "Vous n'avez pas assez d'argent pour acheter cette item.");
                 } else {
-                    int maxStackSize = 64;
+                    int maxStackSize = items.getMaxStack();
                     int totalQuantity = quantity;
                     Material materials = Material.getMaterial((material == null) ? items.named() : (items.named() + "_" + material));
 
@@ -84,13 +84,15 @@ public class AdminShopBuyConfirm extends Menu {
                             "Achat adminshop"
                     ));
 
+                    getOwner().sendMessage("§aAchat confirmé !");
+                    getOwner().sendMessage("  §2+ §a" + totalQuantity + " " + items.getName() + " §7pour §a" + String.format("%.2f", items.getPrize() * totalQuantity) + "$");
+
                     while (totalQuantity > 0) {
                         int stackSize = Math.min(totalQuantity, maxStackSize);
                         getOwner().getInventory().addItem(new ItemStack(materials, stackSize));
                         totalQuantity -= stackSize;
                     }
 
-                    getOwner().sendMessage("§aAchat confirmé !");
                 }
             }
             getOwner().closeInventory();
@@ -121,13 +123,10 @@ public class AdminShopBuyConfirm extends Menu {
             if(is == null || is.getType() == Material.AIR) {
                 continue;
             }
-
             if(is.getType() == item && is.getAmount() < is.getMaxStackSize()) {
                 return true;
             }
         }
-
-
         return player.getInventory().firstEmpty() != -1;
     }
 }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/category/colored/COLOR.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/category/colored/COLOR.java
@@ -2,6 +2,7 @@ package fr.communaywen.core.adminshop.menu.category.colored;
 
 import fr.communaywen.core.adminshop.shopinterfaces.BaseItems;
 import fr.communaywen.core.adminshop.menu.category.ShopType;
+import org.bukkit.Material;
 
 public enum COLOR implements BaseItems {
     WHITE(12, 2, ShopType.BUY, "§7blanc"),
@@ -56,5 +57,11 @@ public enum COLOR implements BaseItems {
     @Override
     public String named() {
         return name();
+    }
+
+    @Override
+    public int getMaxStack() {
+        Material material = Material.getMaterial(this.named());;
+        return material == null ? 64 : material.getMaxStackSize();
     }
 }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/BlocksItems.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/BlocksItems.java
@@ -4,6 +4,7 @@ import fr.communaywen.core.adminshop.shopinterfaces.BaseItems;
 import fr.communaywen.core.adminshop.menu.category.ShopType;
 import fr.communaywen.core.credit.Credit;
 import fr.communaywen.core.credit.Feature;
+import org.bukkit.Material;
 
 @Credit("Axeno")
 @Feature("AdminShop")
@@ -67,4 +68,9 @@ public enum BlocksItems implements BaseItems {
         return name();
     }
 
+    @Override
+    public int getMaxStack() {
+        Material material = Material.getMaterial(this.named());;
+        return material == null ? 64 : material.getMaxStackSize();
+    }
 }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/FoodsItems.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/FoodsItems.java
@@ -2,6 +2,7 @@ package fr.communaywen.core.adminshop.menu.category.defaults;
 
 import fr.communaywen.core.adminshop.shopinterfaces.BaseItems;
 import fr.communaywen.core.adminshop.menu.category.ShopType;
+import org.bukkit.Material;
 
 public enum FoodsItems implements BaseItems {
     COOKED_BEEF(13, 10, ShopType.BUY, "§7Steak"),
@@ -52,5 +53,11 @@ public enum FoodsItems implements BaseItems {
     @Override
     public String named() {
         return name();
+    }
+
+    @Override
+    public int getMaxStack() {
+        Material material = Material.getMaterial(this.named());;
+        return material == null ? 64 : material.getMaxStackSize();
     }
 }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/MiscItems.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/MiscItems.java
@@ -4,6 +4,7 @@ import fr.communaywen.core.adminshop.shopinterfaces.BaseItems;
 import fr.communaywen.core.adminshop.menu.category.ShopType;
 import fr.communaywen.core.credit.Credit;
 import fr.communaywen.core.credit.Feature;
+import org.bukkit.Material;
 
 @Credit("Axeno")
 @Feature("AdminShop")
@@ -52,5 +53,11 @@ public enum MiscItems implements BaseItems {
     @Override
     public String named() {
         return name();
+    }
+
+    @Override
+    public int getMaxStack() {
+        Material material = Material.getMaterial(this.named());;
+        return material == null ? 64 : material.getMaxStackSize();
     }
 }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/OresItems.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/category/defaults/OresItems.java
@@ -1,9 +1,11 @@
 package fr.communaywen.core.adminshop.menu.category.defaults;
 
+import fr.communaywen.core.AywenCraftPlugin;
 import fr.communaywen.core.adminshop.shopinterfaces.BaseItems;
 import fr.communaywen.core.adminshop.menu.category.ShopType;
 import fr.communaywen.core.credit.Credit;
 import fr.communaywen.core.credit.Feature;
+import org.bukkit.Material;
 
 @Credit("Axeno")
 @Feature("AdminShop")
@@ -59,6 +61,12 @@ public enum OresItems implements BaseItems {
     @Override
     public String named() {
         return name();
+    }
+
+    @Override
+    public int getMaxStack() {
+        Material material = Material.getMaterial(this.named());;
+        return material == null ? 64 : material.getMaxStackSize();
     }
 
 }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/sell/AdminShopSell.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/sell/AdminShopSell.java
@@ -116,9 +116,7 @@ public class AdminShopSell extends Menu {
         return new ItemBuilder(this, Objects.requireNonNull(Material.getMaterial(items.named())), itemMeta -> {
             itemMeta.setDisplayName(items.getName());
             updateItemMeta(itemMeta);
-        }).setOnClick(event -> {
-            new AdminShopSellConfirm(getOwner(), items, number.get()).open();
-        });
+        }).setNextMenu(new AdminShopSellConfirm(getOwner(), items, number.get()));
     }
 
     private void updateItemMeta(ItemMeta itemMeta) {
@@ -142,6 +140,8 @@ public class AdminShopSell extends Menu {
                 updateItemMeta(itemMeta);
                 itemStack.setItemMeta(itemMeta);
             }
+
+            inventory.setItem(13, createItemDisplay());
         }
         getOwner().updateInventory();
     }

--- a/src/main/java/fr/communaywen/core/adminshop/menu/sell/AdminShopSellConfirm.java
+++ b/src/main/java/fr/communaywen/core/adminshop/menu/sell/AdminShopSellConfirm.java
@@ -67,7 +67,9 @@ public class AdminShopSellConfirm extends Menu {
 
             removeItemsFromInventory(getOwner(), Material.getMaterial(items.named()), quantity);
             economy.addBalance(getOwner(), totalAmount);
-            getOwner().sendMessage("§aVente confirmée ! Vous avez reçu " + totalAmount + "$.");
+            getOwner().sendMessage("§aVente confirmée !");
+            getOwner().sendMessage("  §4- §c" + quantity + " " + items.getName() + " §7pour §a" + String.format("%.2f", totalAmount) + "$");
+
             getOwner().closeInventory();
         }));
 

--- a/src/main/java/fr/communaywen/core/adminshop/shopinterfaces/BaseItems.java
+++ b/src/main/java/fr/communaywen/core/adminshop/shopinterfaces/BaseItems.java
@@ -12,4 +12,5 @@ public interface BaseItems {
     double getPrize();
     int getSlots();
     ShopType getType();
+    int getMaxStack();
 }


### PR DESCRIPTION
On pouvait acheter plus de 64 enderpearls à la fois + on devait cliquer plusieurs fois pour avoir le menu 