### PR TITLE
Fixed a bug with luckyblocks

### DIFF
--- a/src/main/java/fr/communaywen/core/luckyblocks/listeners/LBBlockBreakListener.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/listeners/LBBlockBreakListener.java
@@ -1,15 +1,20 @@
 package fr.communaywen.core.luckyblocks.listeners;
 
 import dev.lone.itemsadder.api.CustomBlock;
+import fr.communaywen.core.AywenCraftPlugin;
+import fr.communaywen.core.claim.RegionManager;
 import fr.communaywen.core.credit.Credit;
 import fr.communaywen.core.credit.Feature;
 import fr.communaywen.core.luckyblocks.managers.LuckyBlockManager;
 import fr.communaywen.core.luckyblocks.utils.LBUtils;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
 @Feature("Lucky Blocks")
 @Credit("Fnafgameur")
@@ -24,7 +29,20 @@ public class LBBlockBreakListener implements Listener {
     @EventHandler
     public void onBreak(BlockBreakEvent event) {
 
+        Player player = event.getPlayer();
+        String itemName = player.getInventory().getItemInMainHand().getType().name();
+
+        if (itemName.toLowerCase().contains("sword") && player.getGameMode().equals(GameMode.CREATIVE)) {
+            return;
+        }
+
         Block block = event.getBlock();
+
+        if (!LBUtils.canDestroyBlockInClaim(player, block)) {
+            event.setCancelled(true);
+            return;
+        }
+
         CustomBlock customBlock = CustomBlock.byAlreadyPlaced(block);
 
         if (customBlock == null) {
@@ -35,7 +53,6 @@ public class LBBlockBreakListener implements Listener {
             return;
         }
 
-        Player player = event.getPlayer();
         luckyBlockManager.getRandomEvent().onOpen(player, block);
     }
 }

--- a/src/main/java/fr/communaywen/core/luckyblocks/utils/LBUtils.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/utils/LBUtils.java
@@ -1,6 +1,10 @@
 package fr.communaywen.core.luckyblocks.utils;
 
 import dev.lone.itemsadder.api.CustomStack;
+import fr.communaywen.core.AywenCraftPlugin;
+import fr.communaywen.core.claim.RegionManager;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 public class LBUtils {
@@ -9,9 +13,29 @@ public class LBUtils {
         return "luckyblock:luckyblock";
     }
 
+    /**
+     * Get the lucky block item
+     * @return The lucky block item
+     */
     public static ItemStack getLuckyBlockItem() {
         CustomStack lb = CustomStack.getInstance(getBlockNamespaceID());
 
         return lb.getItemStack();
+    }
+
+    /**
+     * Check if a player can destroy a block in a claim
+     * @param player The player involved
+     * @param block The block to destroy
+     * @return True if the player can destroy the block, false otherwise
+     */
+    public static boolean canDestroyBlockInClaim(Player player, Block block) {
+        for (RegionManager region : AywenCraftPlugin.getInstance().regions) {
+            if (region.isInArea(block.getLocation()) && !region.isTeamMember(player.getUniqueId())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
*Avez-vous lu le [Code de Conduite](https://github.com/Margouta/PluginOpenMC/blob/main/CODE_OF_CONDUCT.md)?*: *Oui*

*Votre code se compile-t-il en local ?*: *Oui*

*Avez-vous supprimé les imports inutilisés ?*: *Oui* 
## Décrivez vos changements
**Correction de 2 bugs :**
- Un joueur, s'il était en créatif, pouvait ouvrir un nombre infini de luckyblock en le cassant avec une épée.
- L'event `LBBlockBreakListener` check désormais si le luckyblock cassé est dans un claim et si celui-ci appartient au joueur.