### PR TITLE
Fixed dupe bug with luckyblocks

### DIFF
--- a/src/main/java/fr/communaywen/core/luckyblocks/events/bonus/LBMoonGravity.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/events/bonus/LBMoonGravity.java
@@ -23,7 +23,7 @@ public class LBMoonGravity extends LuckyBlockEvent implements LuckyBlockListener
                 "moon_gravity",
                 "Gravité Lunaire!",
                 "Gravité Lunaire pendant 1 minute !",
-                0.5f,
+                0.4f,
                 EventType.BONUS,
                 new ItemStack(Material.WHITE_WOOL)
         );

--- a/src/main/java/fr/communaywen/core/luckyblocks/events/malus/LBSolarGravity.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/events/malus/LBSolarGravity.java
@@ -23,7 +23,7 @@ public class LBSolarGravity extends LuckyBlockEvent implements LuckyBlockListene
                 "solar_gravity",
                 "Gravité solaire!",
                 "Gravité Solaire pendant 1 minute !",
-                0.5f,
+                0.4f,
                 EventType.MALUS,
                 new ItemStack(Material.ORANGE_WOOL)
         );

--- a/src/main/java/fr/communaywen/core/luckyblocks/events/malus/LBSpawnBob.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/events/malus/LBSpawnBob.java
@@ -24,7 +24,7 @@ public class LBSpawnBob extends LuckyBlockEvent implements LuckyBlockListeners {
         super(
                 "spawn_bob",
                 "Jaloux ?",
-                "§l§4Bob§f est apparu !",
+                "§l§4Bob§7 est apparu !",
                 0.2f,
                 EventType.MALUS,
                 new ItemStack(Material.ZOMBIE_HEAD)

--- a/src/main/java/fr/communaywen/core/luckyblocks/events/malus/LBSpawnShulker.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/events/malus/LBSpawnShulker.java
@@ -19,7 +19,7 @@ public class LBSpawnShulker extends LuckyBlockEvent {
                 "spawn_shulker",
                 "Wingardiuuuum Levioosaaaaa",
                 "Un Shulker est apparu !",
-                0.5f,
+                0.1f,
                 EventType.MALUS,
                 new ItemStack(Material.SHULKER_BOX)
         );

--- a/src/main/java/fr/communaywen/core/luckyblocks/events/neutrals/LBStructureHerobrine.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/events/neutrals/LBStructureHerobrine.java
@@ -24,9 +24,9 @@ public class LBStructureHerobrine extends LuckyBlockEvent {
                 "structure_herobrine",
                 "Un vieil ami",
                 "Apparition de la structure d'Herobrine !",
-                0.5f,
+                0.4f,
                 EventType.NEUTRAL,
-                new ItemStack(Material.PLAYER_HEAD)
+                new ItemStack(Material.NETHERRACK)
         );
     }
 

--- a/src/main/java/fr/communaywen/core/luckyblocks/listeners/LBBlockBreakListener.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/listeners/LBBlockBreakListener.java
@@ -7,10 +7,12 @@ import fr.communaywen.core.luckyblocks.managers.LuckyBlockManager;
 import fr.communaywen.core.luckyblocks.utils.LBUtils;
 import org.bukkit.GameMode;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
 @Feature("Lucky Blocks")
 @Credit("Fnafgameur")
@@ -26,9 +28,18 @@ public class LBBlockBreakListener implements Listener {
     public void onBreak(BlockBreakEvent event) {
 
         Player player = event.getPlayer();
-        String itemName = player.getInventory().getItemInMainHand().getType().name();
+        ItemStack itemInHand = player.getInventory().getItemInMainHand();
+        String itemName = itemInHand.getType().name();
 
         if (itemName.toLowerCase().contains("sword") && player.getGameMode().equals(GameMode.CREATIVE)) {
+            return;
+        }
+
+        if (itemInHand.getEnchantments().containsKey(Enchantment.SILK_TOUCH)) {
+            return;
+        }
+
+        if (event.isCancelled()) {
             return;
         }
 

--- a/src/main/java/fr/communaywen/core/luckyblocks/managers/LuckyBlockManager.java
+++ b/src/main/java/fr/communaywen/core/luckyblocks/managers/LuckyBlockManager.java
@@ -59,6 +59,7 @@ public class LuckyBlockManager {
      */
     public LuckyBlockEvent getRandomEvent() {
 
+        List<LuckyBlockEvent> lbEvents = new ArrayList<>(this.lbEvents);
         LuckyBlockEvent eventToReturn;
         Collections.shuffle(lbEvents);
 


### PR DESCRIPTION
*Avez-vous lu le [Code de Conduite](https://github.com/Margouta/PluginOpenMC/blob/main/CODE_OF_CONDUCT.md)?*: *Oui*

*Votre code se compile-t-il en local ?*: *Oui*

*Avez-vous supprimé les imports inutilisés ?*: *Oui*
## Décrivez vos changements
Patch d'un bug où les joueurs pouvaient dupliquer les events des luckyblocks en les cassants soit avec une pioche avec l'enchant `silk touch` soit avec un hammer.